### PR TITLE
Fix minimum required platformdirs version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "inventree>=0.13.2",
   "isocodes",
   "mouser>=0.1.5",
-  "platformdirs",
+  "platformdirs>=3.2.0",
   "pyyaml",
   "requests",
   "tablib",


### PR DESCRIPTION
This sets the minimum required platformdirs version to `3.2.0` since `ensure_exists` does not exists before `3.2.0`: https://github.com/platformdirs/platformdirs/commit/fd0172a3a375c53737cade44cb6155ac8f243344

`ensure_exists` is used in the following places:

* https://github.com/30350n/inventree_part_import/blob/8dcd9dcaa901c33ecddf1f0c4767363491fff0b8/inventree_part_import/inventree_helpers.py#L20
* https://github.com/30350n/inventree_part_import/blob/8dcd9dcaa901c33ecddf1f0c4767363491fff0b8/inventree_part_import/suppliers/supplier_digikey.py#L12

This prevents `TypeError: user_cache_path() got an unexpected keyword argument 'ensure_exists'` when running inventree_part_import in environments with older versions of platformdirs installed.