### PR TITLE
Allow overwriting part names

### DIFF
--- a/inventree_part_import/cli.py
+++ b/inventree_part_import/cli.py
@@ -57,6 +57,11 @@ InteractiveChoices = click.Choice(("default", "false", "true", "twice"), case_se
 @click.option("-d", "--dry", is_flag=True, help="Run without modifying InvenTree database.")
 @click.option("-c", "--config-dir", help="Override path to config directory.")
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose output for debugging.")
+@click.option("--overwrite-part-name", help=(
+    "Override name of the part related to the search results. "
+    "If multiple search terms are given, all resulting manufacturer/supplier parts "
+    "will point to the same part."
+))
 @click.option("--show-config-dir", is_flag=True, help="Show path to config directory and exit.")
 @click.option("--configure", type=AvailableSuppliersChoices, help="Configure supplier.")
 @click.option("--update", metavar="CATEGORY", help="Update all parts from InvenTree CATEGORY.")
@@ -74,6 +79,7 @@ def inventree_part_import(
     dry=False,
     config_dir=False,
     verbose=False,
+    overwrite_part_name=None,
     show_config_dir=False,
     configure=None,
     update=None,
@@ -203,9 +209,9 @@ def inventree_part_import(
     try:
         for index, part in enumerate(parts):
             last_import_result = (
-                importer.import_part(part.name, part, supplier, only_supplier)
+                importer.import_part(part.name, part, supplier, only_supplier, overwrite_part_name)
                 if isinstance(part, Part) else
-                importer.import_part(part, None, supplier, only_supplier)
+                importer.import_part(part, None, supplier, only_supplier, overwrite_part_name)
             )
             print()
             match last_import_result:
@@ -227,9 +233,9 @@ def inventree_part_import(
             importer.interactive = True
             for part in parts2:
                 import_result = (
-                    importer.import_part(part.name, part, supplier, only_supplier)
+                    importer.import_part(part.name, part, supplier, only_supplier, overwrite_part_name)
                     if isinstance(part, Part) else
-                    importer.import_part(part, None, supplier, only_supplier)
+                    importer.import_part(part, None, supplier, only_supplier, overwrite_part_name)
                 )
                 match import_result:
                     case ImportResult.ERROR | ImportResult.FAILURE:

--- a/inventree_part_import/part_importer.py
+++ b/inventree_part_import/part_importer.py
@@ -51,7 +51,8 @@ class PartImporter:
             search_term,
             existing_part: Part = None,
             supplier_id=None,
-            only_supplier=False
+            only_supplier=False,
+            overwrite_part_name=None
         ):
         info(f"searching for {search_term} ...", end="\n")
         import_result = ImportResult.SUCCESS
@@ -68,6 +69,8 @@ class PartImporter:
 
             if len(results) == 1:
                 api_part = results[0]
+                if overwrite_part_name is not None:
+                    api_part.name = overwrite_part_name
             elif self.interactive:
                 prompt(f"found multiple parts at {supplier.name}, select which one to import")
                 results = results[:get_config()["max_results"]]
@@ -167,7 +170,7 @@ class PartImporter:
             if update_part:
                 if not api_part.finalize():
                     return ImportResult.FAILURE
-                update_object_data(part, api_part.get_part_data(), f"part {api_part.MPN}")
+                update_object_data(part, api_part.get_part_data(), f"part {api_part.name}")
 
             if not part.image and api_part.image_url:
                 upload_image(part, api_part.image_url)
@@ -217,8 +220,8 @@ class PartImporter:
         part: Part = None,
     ) -> tuple[ManufacturerPart, Part]:
         part_data = api_part.get_part_data()
-        if part or (part := get_part(self.api, api_part.MPN)):
-            update_object_data(part, part_data, f"part {api_part.MPN}")
+        if part or (part := get_part(self.api, api_part.name)):
+            update_object_data(part, part_data, f"part {api_part.name}")
         else:
             for subcategory in reversed(api_part.category_path):
                 if category := self.category_map.get(subcategory.lower()):
@@ -236,7 +239,7 @@ class PartImporter:
                 category.add_alias(api_part.category_path[-1])
                 self.category_map[api_part.category_path[-1].lower()] = category
 
-            info(f"creating part {api_part.MPN} in '{category.part_category.pathstring}' ...")
+            info(f"creating part {api_part.name} in '{category.part_category.pathstring}' ...")
             part = Part.create(self.api, {"category": category.part_category.pk, **part_data})
 
         manufacturer = create_manufacturer(self.api, api_part.manufacturer)

--- a/inventree_part_import/suppliers/base.py
+++ b/inventree_part_import/suppliers/base.py
@@ -8,6 +8,7 @@ from ..error_helper import error
 
 @dataclass
 class ApiPart:
+    name: str
     description: str
     image_url: str
     datasheet_url: str
@@ -35,7 +36,7 @@ class ApiPart:
 
     def get_part_data(self):
         return {
-            "name": self.MPN,
+            "name": self.name,
             "description": self.description,
             "link": self.manufacturer_link[:200],
             "active": True,

--- a/inventree_part_import/suppliers/supplier_digikey.py
+++ b/inventree_part_import/suppliers/supplier_digikey.py
@@ -96,6 +96,7 @@ class DigiKey(Supplier):
         }
 
         return ApiPart(
+            name=digikey_part.manufacturer_part_number,
             description=digikey_part.product_description,
             image_url=digikey_part.primary_photo,
             datasheet_url=digikey_part.primary_datasheet,
@@ -109,5 +110,5 @@ class DigiKey(Supplier):
             category_path=category_path,
             parameters=parameters,
             price_breaks=price_breaks,
-            currency=self.currency,
+            currency=self.currency
         )

--- a/inventree_part_import/suppliers/supplier_lcsc.py
+++ b/inventree_part_import/suppliers/supplier_lcsc.py
@@ -113,6 +113,7 @@ class LCSC(Supplier):
             currency = self.currency
 
         return ApiPart(
+            name=lcsc_part.get("productModel", ""),
             description=REMOVE_HTML_TAGS.sub("", description),
             image_url=image_url,
             datasheet_url=lcsc_part.get("pdfUrl"),

--- a/inventree_part_import/suppliers/supplier_mouser.py
+++ b/inventree_part_import/suppliers/supplier_mouser.py
@@ -72,6 +72,7 @@ class Mouser(Supplier):
             quantity_available = 0
 
         api_part = ApiPart(
+            name=mouser_part.get("ManufacturerPartNumber", ""),
             description=REMOVE_HTML_TAGS.sub("", mouser_part.get("Description", "")),
             image_url=mouser_part.get("ImagePath"),
             datasheet_url=mouser_part.get("DataSheetUrl"),

--- a/inventree_part_import/suppliers/supplier_reichelt.py
+++ b/inventree_part_import/suppliers/supplier_reichelt.py
@@ -129,6 +129,7 @@ class Reichelt(Supplier):
             currency = meta["content"]
 
         return ApiPart(
+            name=mpn,
             description=description,
             image_url=image_url,
             datasheet_url=datasheet_url,

--- a/inventree_part_import/suppliers/supplier_tme.py
+++ b/inventree_part_import/suppliers/supplier_tme.py
@@ -75,6 +75,7 @@ class TME(Supplier):
         }
 
         api_part = ApiPart(
+            name=tme_part.get("OriginalSymbol", ""),
             description=tme_part.get("Description", ""),
             image_url=fix_tme_url(tme_part.get("Photo")),
             datasheet_url=None,


### PR DESCRIPTION
# Summary

This PR adds functionality to overwrite part names associated to supplier/manufacturer parts.

# Problem

In some cases, parts can have multiple different manufacturers and MPNs, but are essentially the same. For example, there is a multitude of [10-pin 2.54mm 2x5 shrouded headers](https://www.digikey.de/de/products/filter/rechteckige-steckverbinder/steckleisten-stifte/314?s=N4IgjCBcoKxaBjKAzAhgGwM4FMA0IB7KAbRAGYA2AJhjAE4QBdfABwBcoQBlNgJwEsAdgHMQAX3wUK8EEkhoseQiRBUADGBh0ALE1YdI3PkNESQFBtFkoMOfEUiltYMAA46Adj0h2nHgJFxfFdXGTkFO2VHczI6V2lmHwMjANN8OjUwm0V7FTAqMDIqBP0-Y0CzWlCrcNslB1JYtU8IRN9DfxMgkBh3LPk63OjtNRg1NSpvdpSuszALMn6I%2BpUyejoqBjbkzor8MA8MpcGo0k9iqZ3ytPBDiBrsyIbyMcOSpLLU7vo%2Bh4Gc04gTKMMzqFzHAHPEZSKSXT6zfDqAoQp4qEYFDxebbwvYgAC0kz%2BfAAritonAQfg8YsibxSUNSGBgWY8ZZEFASWTGUwxLygA), which for almost all intents and purposes are identical.

For items like these, it does not make sense to keep seperate stock or even treat them differently in any way. However, currently `inventree-part-import` does not support such a scenario.

# Description

This PR adds functionality to overwrite part names associated to supplier/manufacturer parts. With this, it's possible to store multiple similar supplier/manufacturer into the same part.

For example,
```sh
inventree-part-import --overwrite-part-name Header-254-16P-S 302-S161 BHR-16-VUA SBH11-PBPC-D08-ST-BK
```
will store multiple of the aforementioned headers into the same part, `Header-254-16P-S`. This keeps the parts minimal, allows keeping one stock item for all different supply/manufacturer parts and in general simplifies handling.