### PR TITLE
Fix small issue in recent update to LCSC (adjust json.get to json().get)

### DIFF
--- a/inventree_part_import/suppliers/supplier_lcsc.py
+++ b/inventree_part_import/suppliers/supplier_lcsc.py
@@ -34,7 +34,7 @@ class LCSC(Supplier):
             url = PRODUCT_INFO_URL.format(product_detail["productCode"])
             for _ in range(3):
                 detail_request = scrape(url, setup_hook=self.setup_hook)
-                if detail_request and (detail_result := detail_request.json.get("result")):
+                if detail_request and (detail_result := detail_request.json().get("result")):
                     return [self.get_api_part(detail_result)], 1
                 print("retry")
             warning("failed to retrieve product data from LCSC (internal API error)")


### PR DESCRIPTION
I've been working on another pull request (coming shortly) and ran into an LCSC import issue.  It looks like the latest update to add retry for LCSC (in the latest/non-released version) has a small typo (json.get needs to be json().get).  I assume you will fix this yourself, but I thought I'd send it over just in case anyone else runs into it before you have the opportunity.  

Thanks for the great work on this package!