### PR TITLE
truncate LCSC description longer than 250 characters

### DIFF
--- a/inventree_part_import/suppliers/supplier_lcsc.py
+++ b/inventree_part_import/suppliers/supplier_lcsc.py
@@ -72,6 +72,7 @@ class LCSC(ScrapeSupplier):
         if not (description := lcsc_part.get("productDescEn")):
             description = lcsc_part.get("productIntroEn")
         description = description.strip() if description else ""
+        description = (description[:247] + '..') if len(description) > 250 else description
 
         image_url = lcsc_part.get("productImageUrlBig", lcsc_part.get("productImageUrl"))
         if not image_url and (image_urls := lcsc_part.get("productImages")):


### PR DESCRIPTION
InvenTree is not accepting descriptions which are longer than 250 characters. Today I stumbled on a part which had a much longer description than 250 characters.
This PR will truncate the description field to 249 characters if it is longer than 250 characters.