### PR TITLE
Support new generic Parameters API (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Additionally you can define the following meta attributes (starting with `_`):
   **note: parameters get inherited by sub categories**
 - `_omit_parameters` has to be a list of parameters names defined in parent categories that
   get omitted from the category
+  **note: this is disfunctional in InvenTree >= 1.2.0 as parameter inheritance happens directly in InvenTree**
 - `_structural` can be set to `true` to make the category structural
 
 Here's an example for a config with special attributes:

--- a/inventree_part_import/categories.py
+++ b/inventree_part_import/categories.py
@@ -14,7 +14,7 @@ def setup_categories_and_parameters(inventree_api):
     parameters_config = get_parameters_config(inventree_api)
 
     info("setting up categories ...")
-    categories = parse_category_recursive(categories_config)
+    categories = parse_category_recursive(inventree_api, categories_config)
     parameters = parse_parameters(parameters_config)
 
     used_parameters = set.union(set(), *(set(c.parameters) for c in categories.values()))
@@ -198,7 +198,7 @@ class Category:
 CATEGORY_ATTRIBUTES = {
     "_parameters", "_omit_parameters", "_description", "_ignore", "_structural", "_aliases"
 }
-def parse_category_recursive(categories_dict, parent_parameters=tuple(), path=tuple()):
+def parse_category_recursive(inventree_api, categories_dict, parent=None):
     if not categories_dict:
         return {}
 
@@ -218,24 +218,31 @@ def parse_category_recursive(categories_dict, parent_parameters=tuple(), path=tu
                 warning(f"ignoring unknown special attribute '{child}' in category '{name}'")
 
         omitted_parameters = values.get("_omit_parameters", [])
-        # parameters = tuple(set(parent_parameters) - set(omitted_parameters))
-        # parameters += tuple(values.get("_parameters", []))
-        parameters = tuple(values.get("_parameters", []))
-        for parameter in set(omitted_parameters) - set(parent_parameters):
-            warning(f"failed to omit parameter '{parameter}' in category '{name}'")
+        parameters = []
+        # https://github.com/inventree/InvenTree/pull/10699
+        if inventree_api.api_version < 429 and parent:
+            parameters += list(set(parent.parameters) - set(omitted_parameters))
+            for parameter in set(omitted_parameters) - set(parent.parameters):
+                warning(f"failed to omit parameter '{parameter}' in category '{name}'")
+        elif omitted_parameters:
+            warning(
+                "_omit_parameters is disfunctional for InvenTree >= 1.2.0 "
+                "(parent parameters are inherited automatically)"
+            )
+        parameters += values.get("_parameters", [])
 
-        new_path = path + (name,)
-        categories[new_path] = Category(
+        category = Category(
             name=name,
-            path=list(new_path),
+            path=(parent.path if parent else []) + [name],
             description=values.get("_description", name),
             ignore=values.get("_ignore", False),
             structural=values.get("_structural", False),
             aliases=values.get("_aliases", []),
-            parameters=list(parameters),
+            parameters=parameters,
         )
+        categories[tuple(category.path)] = category
 
-        categories.update(parse_category_recursive(values, tuple(), new_path))
+        categories.update(parse_category_recursive(inventree_api, values, category))
 
     return categories
 

--- a/inventree_part_import/categories.py
+++ b/inventree_part_import/categories.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field
 
 from error_helper import info, success, warning
-from inventree.part import ParameterTemplate, PartCategory, PartCategoryParameterTemplate
+from inventree.base import ParameterTemplate
+from inventree.part import PartCategory, PartCategoryParameterTemplate
 
 from .config import (CATEGORIES_CONFIG, PARAMETERS_CONFIG, get_categories_config,
                      get_parameters_config, update_config_file)
@@ -104,7 +105,7 @@ def setup_categories_and_parameters(inventree_api):
         category.part_category.pk: category for category in categories.values()
     }
     part_category_parameter_templates = {
-        (category, template.parameter_template_detail["name"])
+        (category, template.template_detail["name"])
         for template in PartCategoryParameterTemplate.list(inventree_api)
         if (category := part_category_pk_to_category.get(template.category))
     }
@@ -116,7 +117,7 @@ def setup_categories_and_parameters(inventree_api):
             info(f"creating parameter template '{parameter}' for '{category_str}' ...")
             PartCategoryParameterTemplate.create(inventree_api, {
                 "category": category.part_category.pk,
-                "parameter_template": parameter_templates[parameter].pk,
+                "template": parameter_templates[parameter].pk,
             })
 
     for category, template_name in part_category_parameter_templates:
@@ -217,8 +218,9 @@ def parse_category_recursive(categories_dict, parent_parameters=tuple(), path=tu
                 warning(f"ignoring unknown special attribute '{child}' in category '{name}'")
 
         omitted_parameters = values.get("_omit_parameters", [])
-        parameters = tuple(set(parent_parameters) - set(omitted_parameters))
-        parameters += tuple(values.get("_parameters", []))
+        # parameters = tuple(set(parent_parameters) - set(omitted_parameters))
+        # parameters += tuple(values.get("_parameters", []))
+        parameters = tuple(values.get("_parameters", []))
         for parameter in set(omitted_parameters) - set(parent_parameters):
             warning(f"failed to omit parameter '{parameter}' in category '{name}'")
 
@@ -230,10 +232,10 @@ def parse_category_recursive(categories_dict, parent_parameters=tuple(), path=tu
             ignore=values.get("_ignore", False),
             structural=values.get("_structural", False),
             aliases=values.get("_aliases", []),
-            parameters=parameters,
+            parameters=list(parameters),
         )
 
-        categories.update(parse_category_recursive(values, parameters, new_path))
+        categories.update(parse_category_recursive(values, tuple(), new_path))
 
     return categories
 
@@ -304,12 +306,12 @@ def setup_config_from_inventree(inventree_api):
 
     parameters = {}
     for template in PartCategoryParameterTemplate.list(inventree_api):
-        parameter_name = template.parameter_template_detail["name"]
+        parameter_name = template.template_detail["name"]
         if parameter_name not in parameters:
             fields = {}
-            if units := template.parameter_template_detail["units"]:
+            if units := template.template_detail["units"]:
                 fields["_unit"] = units
-            if (desc := template.parameter_template_detail["description"]) != parameter_name:
+            if (desc := template.template_detail["description"]) != parameter_name:
                 fields["_description"] = desc
             parameters[parameter_name] = fields
 

--- a/inventree_part_import/categories.py
+++ b/inventree_part_import/categories.py
@@ -1,6 +1,8 @@
+import sys
 from dataclasses import dataclass, field
 
-from error_helper import info, success, warning
+from cutie import prompt_yes_or_no
+from error_helper import hint, info, success, warning
 from inventree.base import ParameterTemplate
 from inventree.part import PartCategory, PartCategoryParameterTemplate
 
@@ -98,11 +100,16 @@ def setup_categories_and_parameters(inventree_api):
                 "units": parameter.units,
             })
 
-    category_parameters = {
-        (category, param) for category in categories.values() for param in category.parameters
-    }
     part_category_pk_to_category = {
         category.part_category.pk: category for category in categories.values()
+    }
+
+    # https://github.com/inventree/InvenTree/pull/10699
+    if inventree_api.api_version >= 429:
+        migrate_parameter_templates(inventree_api, part_category_pk_to_category)
+
+    category_parameters = {
+        (category, param) for category in categories.values() for param in category.parameters
     }
     part_category_parameter_templates = {
         (category, template.template_detail["name"])
@@ -153,6 +160,39 @@ def setup_categories_and_parameters(inventree_api):
     success("setup categories!", end="\n\n")
 
     return category_map, parameter_map
+
+def migrate_parameter_templates(inventree_api, part_category_pk_to_category):
+    category_templates = {}
+    for template in PartCategoryParameterTemplate.list(inventree_api):
+        if category := part_category_pk_to_category.get(template.category):
+            category_templates.setdefault(category, {})[template.template] = template
+
+    inherited_category_templates = [
+        template
+        for category, templates in category_templates.items()
+        for base_template_pk, template in templates.items()
+        if (parent_category := part_category_pk_to_category.get(category.part_category.parent))
+        if base_template_pk in category_templates.get(parent_category, [])
+    ]
+
+    if inherited_category_templates:
+        warning(
+            f"found {len(inherited_category_templates)} invalid PartCategoryParameterTemplates "
+            "which will have to be DELETED to continue operation",
+        )
+        hint(
+            "visit https://github.com/30350n/inventree-part-import/pull/92#issuecomment-4268494064 "
+            "to learn more"
+        )
+        result = prompt_yes_or_no(
+            f"delete {len(inherited_category_templates)} invalid PartCategoryParameterTemplates?",
+            default_is_yes=True,
+        )
+        if result:
+            for template in inherited_category_templates:
+                template.delete()
+        else:
+            sys.exit(0)
 
 @dataclass
 class Category:

--- a/inventree_part_import/inventree_helpers.py
+++ b/inventree_part_import/inventree_helpers.py
@@ -8,10 +8,10 @@ import requests
 from error_helper import info, warning
 from fake_useragent import UserAgent
 from inventree.api import InvenTreeAPI
-from inventree.base import ImageMixin, InventreeObject
+from inventree.base import ImageMixin, InventreeObject, ParameterTemplate
 from inventree.company import Company as InventreeCompany
 from inventree.company import ManufacturerPart, SupplierPart
-from inventree.part import ParameterTemplate, Part, PartCategory
+from inventree.part import Part, PartCategory
 from platformdirs import user_cache_path
 from requests.compat import unquote, urlparse
 from requests.exceptions import ConnectionError, HTTPError, Timeout

--- a/inventree_part_import/part_importer.py
+++ b/inventree_part_import/part_importer.py
@@ -5,8 +5,9 @@ from string import Formatter, _string
 
 from cutie import select
 from error_helper import BOLD, BOLD_END, error, hint, info, prompt, prompt_input, success, warning
+from inventree.base import Parameter
 from inventree.company import Company, ManufacturerPart, SupplierPart, SupplierPriceBreak
-from inventree.part import Parameter, Part
+from inventree.part import Part
 from requests.compat import quote
 from requests.exceptions import HTTPError
 from thefuzz import fuzz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "cutie",
     "error-helper",
     "fake-useragent",
-    "inventree>=0.23.1",
+    "inventree>=0.20",
     "isocodes",
     "mouser>=0.1.5",
     "platformdirs>=3.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "cutie",
     "error-helper",
     "fake-useragent",
-    "inventree>=0.13.2,<0.20.0",
+    "inventree>=0.23.1",
     "isocodes",
     "mouser>=0.1.5",
     "platformdirs>=3.2.0",


### PR DESCRIPTION
Update to inventree 0.23.1 (https://github.com/inventree/inventree-python/releases/tag/0.23.1) and according changes.

I modified the logic of Categories updates:
Before: parameters + all parent parameters were added to the category's parameters in Inventree
After : only category's parameter are added to the category's parameters in Inventree

This is required, because now Inventree add parent parameters automatically. Adding them 2 times causes duplicate errors.

Fixes #83.