### PR TITLE
Fix compatibility with inventree-python >=0.20.0 and InvenTree 1.x

### DIFF
--- a/inventree_part_import/categories.py
+++ b/inventree_part_import/categories.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field
 
 from error_helper import info, success, warning
-from inventree.part import ParameterTemplate, PartCategory, PartCategoryParameterTemplate
+from inventree.base import ParameterTemplate
+from inventree.part import PartCategory, PartCategoryParameterTemplate
 
 from .config import (CATEGORIES_CONFIG, PARAMETERS_CONFIG, get_categories_config,
                      get_parameters_config, update_config_file)
@@ -97,6 +98,9 @@ def setup_categories_and_parameters(inventree_api):
                 "units": parameter.units,
             })
 
+    category_own_parameters = {
+        (category, param) for category in categories.values() for param in category.own_parameters
+    }
     category_parameters = {
         (category, param) for category in categories.values() for param in category.parameters
     }
@@ -104,19 +108,19 @@ def setup_categories_and_parameters(inventree_api):
         category.part_category.pk: category for category in categories.values()
     }
     part_category_parameter_templates = {
-        (category, template.parameter_template_detail["name"])
+        (category, template.template_detail["name"])
         for template in PartCategoryParameterTemplate.list(inventree_api)
         if (category := part_category_pk_to_category.get(template.category))
     }
 
-    for category_parameter in category_parameters:
+    for category_parameter in category_own_parameters:
         if category_parameter not in part_category_parameter_templates:
             category, parameter = category_parameter
             category_str = "/".join(category.path)
             info(f"creating parameter template '{parameter}' for '{category_str}' ...")
             PartCategoryParameterTemplate.create(inventree_api, {
                 "category": category.part_category.pk,
-                "parameter_template": parameter_templates[parameter].pk,
+                "template": parameter_templates[parameter].pk,
             })
 
     for category, template_name in part_category_parameter_templates:
@@ -162,6 +166,7 @@ class Category:
     structural: bool
     aliases: list[str] = field(default_factory=list)
     parameters: list[str] = field(default_factory=list)
+    own_parameters: list[str] = field(default_factory=list)
     part_category: PartCategory = None
 
     def __hash__(self):
@@ -217,8 +222,9 @@ def parse_category_recursive(categories_dict, parent_parameters=tuple(), path=tu
                 warning(f"ignoring unknown special attribute '{child}' in category '{name}'")
 
         omitted_parameters = values.get("_omit_parameters", [])
+        own_parameters = tuple(values.get("_parameters", []))
         parameters = tuple(set(parent_parameters) - set(omitted_parameters))
-        parameters += tuple(values.get("_parameters", []))
+        parameters += own_parameters
         for parameter in set(omitted_parameters) - set(parent_parameters):
             warning(f"failed to omit parameter '{parameter}' in category '{name}'")
 
@@ -231,6 +237,7 @@ def parse_category_recursive(categories_dict, parent_parameters=tuple(), path=tu
             structural=values.get("_structural", False),
             aliases=values.get("_aliases", []),
             parameters=parameters,
+            own_parameters=own_parameters,
         )
 
         categories.update(parse_category_recursive(values, parameters, new_path))
@@ -304,12 +311,12 @@ def setup_config_from_inventree(inventree_api):
 
     parameters = {}
     for template in PartCategoryParameterTemplate.list(inventree_api):
-        parameter_name = template.parameter_template_detail["name"]
+        parameter_name = template.template_detail["name"]
         if parameter_name not in parameters:
             fields = {}
-            if units := template.parameter_template_detail["units"]:
+            if units := template.template_detail["units"]:
                 fields["_unit"] = units
-            if (desc := template.parameter_template_detail["description"]) != parameter_name:
+            if (desc := template.template_detail["description"]) != parameter_name:
                 fields["_description"] = desc
             parameters[parameter_name] = fields
 

--- a/inventree_part_import/inventree_helpers.py
+++ b/inventree_part_import/inventree_helpers.py
@@ -8,10 +8,10 @@ import requests
 from error_helper import info, warning
 from fake_useragent import UserAgent
 from inventree.api import InvenTreeAPI
-from inventree.base import ImageMixin, InventreeObject
+from inventree.base import ImageMixin, InventreeObject, ParameterTemplate
 from inventree.company import Company as InventreeCompany
 from inventree.company import ManufacturerPart, SupplierPart
-from inventree.part import ParameterTemplate, Part, PartCategory
+from inventree.part import Part, PartCategory
 from platformdirs import user_cache_path
 from requests.compat import unquote, urlparse
 from requests.exceptions import ConnectionError, HTTPError, Timeout

--- a/inventree_part_import/part_importer.py
+++ b/inventree_part_import/part_importer.py
@@ -6,7 +6,8 @@ from string import Formatter, _string
 from cutie import select
 from error_helper import BOLD, BOLD_END, error, hint, info, prompt, prompt_input, success, warning
 from inventree.company import Company, ManufacturerPart, SupplierPart, SupplierPriceBreak
-from inventree.part import Parameter, Part
+from inventree.base import Parameter
+from inventree.part import Part
 from requests.compat import quote
 from requests.exceptions import HTTPError
 from thefuzz import fuzz
@@ -328,7 +329,7 @@ class PartImporter:
 
         existing_parameters = {
             parameter.template_detail["name"]: parameter
-            for parameter in Parameter.list(self.api, part=part.pk)
+            for parameter in Parameter.list(self.api, model_type='part', model_id=part.pk)
         }
 
         matched_parameters = {}
@@ -447,7 +448,8 @@ class PartImporter:
 def create_parameter(inventree_api, part, parameter_template, value):
     try:
         Parameter.create(inventree_api, {
-            "part": part.pk,
+            "model_type": "part",
+            "model_id": part.pk,
             "template": parameter_template.pk,
             "data": value,
         })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "cutie",
     "error-helper",
     "fake-useragent",
-    "inventree>=0.13.2,<0.20.0",
+    "inventree>=0.20.0,<0.24.0",
     "isocodes",
     "mouser>=0.1.5",
     "platformdirs>=3.2.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import yaml
 from click.testing import CliRunner
 from inventree.api import InvenTreeAPI
-from inventree.part import ParameterTemplate, PartCategory
+from inventree.base import ParameterTemplate
+from inventree.part import PartCategory
 
 from inventree_part_import.categories import setup_config_from_inventree
 from inventree_part_import.cli import inventree_part_import


### PR DESCRIPTION
## Summary
- Update `inventree` dependency to `>=0.20.0,<0.24.0`
- Fix import paths: `ParameterTemplate` and `Parameter` moved from `inventree.part` to `inventree.base`
- Update API field names: `parameter_template` → `template`, `parameter_template_detail` → `template_detail`
- Use generic parameter API (`model_type`/`model_id`) instead of `part=pk` for `Parameter.list()` and `Parameter.create()`
- Fix duplicate `PartCategoryParameterTemplate` creation by tracking own parameters separately from inherited ones (prevents `IntegrityError`)

Closes #94

## Test plan
- Tested against InvenTree 1.2.6 (API 453) with `inventree-python` 0.23.x
- Successfully imported parts from DigiKey with correct parameter assignment
- No duplicate parameter template errors on categories with inherited parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)