### PR TITLE
Search part via Mouser IBN

### DIFF
--- a/inventree_part_import/cli.py
+++ b/inventree_part_import/cli.py
@@ -16,6 +16,45 @@ from .inventree_helpers import get_category, get_category_parts
 from .part_importer import ImportResult, PartImporter
 from .suppliers import get_suppliers, setup_supplier_companies
 
+
+def _resolve_mouser_ibn(ibn_code):
+    suppliers, _ = get_suppliers(reload=True, setup=False)
+    if (mouser := suppliers.get("mouser")) is None:
+        error("Mouser supplier is not configured, cannot use --ibn")
+        return None
+
+    results = mouser.search_by_ibn(ibn_code)
+    if not results:
+        error(f"no results for IBN '{ibn_code}'")
+        return None
+
+    if len(results) == 1:
+        manufacturer_part = results[0].get("ManufacturerPartNumber")
+        if not manufacturer_part:
+            error("invalid IBN result: missing ManufacturerPartnumber")
+            return None
+        return manufacturer_part
+
+    prompt(f"found {len(results)} IBN matches at Mouser, select which one to use")
+    choices = [
+        f"{item.get('MouserPartNumber', 'N/A')} | {item.get('MouserDescription', 'N/A')}"
+        for item in results
+    ]
+    choices.append("Cancel")
+    choice_index = select(choices, deselected_prefix="  ", selected_prefix="> ")
+    if choice_index == len(choices) - 1:
+        warning("IBN selection cancelled")
+        return None
+
+    selected = results[choice_index]
+    manufacturer_part = selected.get("ManufacturerPartnumber")
+    if not manufacturer_part:
+        error("invalid IBN result: missing ManufacturerPartnumber")
+        return None
+
+    return manufacturer_part
+
+
 def handle_errors(func):
     def wrapper(*args, **kwargs):
         try:
@@ -56,6 +95,7 @@ InteractiveChoices = click.Choice(("default", "false", "true", "twice"), case_se
 @click.option("-d", "--dry", is_flag=True, help="Run without modifying InvenTree database.")
 @click.option("-c", "--config-dir", help="Override path to config directory.")
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose output for debugging.")
+@click.option("--ibn", help="Search by Mouser IBN.")
 @click.option("--show-config-dir", is_flag=True, help="Show path to config directory and exit.")
 @click.option("--configure", type=AvailableSuppliersChoices, help="Configure supplier.")
 @click.option("--update", metavar="CATEGORY", help="Update all parts from InvenTree CATEGORY.")
@@ -73,6 +113,7 @@ def inventree_part_import(
     dry=False,
     config_dir=False,
     verbose=False,
+    ibn=None,
     show_config_dir=False,
     configure=None,
     update=None,
@@ -127,7 +168,7 @@ def inventree_part_import(
                 suppliers_config[configure] = new_config
         return
 
-    if not inputs and not (update or update_recursive):
+    if not inputs and not (update or update_recursive or ibn):
         click.echo(context.get_help())
         return
 
@@ -144,6 +185,10 @@ def inventree_part_import(
         supplier = only
         only_supplier = True
 
+    if ibn and (update or update_recursive or inputs):
+        error("--ibn cannot be used with --update, --update-recursive, or input arguments")
+        return
+
     if verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
@@ -155,7 +200,11 @@ def inventree_part_import(
     else:
         inventree_api = setup_inventree_api()
 
-    if (category_path := update_recursive or update):
+    if ibn:
+        if not (manufacturer_part := _resolve_mouser_ibn(ibn)):
+            return
+        parts = [manufacturer_part]
+    elif (category_path := update_recursive or update):
         if update_recursive and update:
             hint("--update is being overridden by --update-recursive")
 

--- a/inventree_part_import/cli.py
+++ b/inventree_part_import/cli.py
@@ -58,6 +58,42 @@ def handle_errors(func: Callable[P, None]) -> Callable[P, None]:
     return wrapper
 
 
+def _resolve_mouser_ibn(ibn_code):
+    suppliers, _ = get_suppliers(reload=True, setup=False)
+    if (mouser := suppliers.get("mouser")) is None:
+        error("Mouser supplier is not configured, cannot use --ibn")
+        return None
+
+    results = mouser.search_by_ibn(ibn_code)
+    if not results:
+        error(f"no results for IBN '{ibn_code}'")
+        return None
+
+    if len(results) == 1:
+        manufacturer_part = results[0].get("ManufacturerPartNumber")
+        if not manufacturer_part:
+            error("invalid IBN result: missing ManufacturerPartnumber")
+            return None
+        return manufacturer_part
+
+    prompt(f"found {len(results)} IBN matches at Mouser, select which one to use")
+    choices = [
+        f"{item.get('MouserPartNumber', 'N/A')} | {item.get('MouserDescription', 'N/A')}"
+        for item in results
+    ]
+    choices.append("Cancel")
+    choice_index = select(choices, deselected_prefix="  ", selected_prefix="> ")
+    if choice_index == len(choices) - 1:
+        warning("IBN selection cancelled")
+        return None
+
+    selected = results[choice_index]
+    manufacturer_part = selected.get("ManufacturerPartnumber")
+    if not manufacturer_part:
+        error("invalid IBN result: missing ManufacturerPartnumber")
+        return None
+    return manufacturer_part
+
 _suppliers, _available_suppliers = get_suppliers(setup=False)
 SuppliersChoices = click.Choice(_suppliers.keys(), case_sensitive=False)
 AvailableSuppliersChoices = click.Choice(_available_suppliers.keys(), case_sensitive=False)
@@ -85,6 +121,7 @@ InteractiveChoices = click.Choice(("default", "false", "true", "twice"), case_se
     "-c", "--config-dir", type=click.Path(path_type=Path), help="Override path to config directory."
 )
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose output for debugging.")
+@click.option("--ibn", help="Search by Mouser IBN.")
 @click.option("--show-config-dir", is_flag=True, help="Show path to config directory and exit.")
 @click.option("--configure", type=AvailableSuppliersChoices, help="Configure supplier.")
 @click.option("--update", metavar="CATEGORY", help="Update all parts from InvenTree CATEGORY.")
@@ -104,6 +141,7 @@ def inventree_part_import(
     dry: bool = False,
     config_dir: Path | None = None,
     verbose: bool = False,
+    ibn: str | None = None,
     show_config_dir: bool = False,
     configure: str | None = None,
     update: str | None = None,
@@ -160,7 +198,7 @@ def inventree_part_import(
                 suppliers_config[configure] = new_config
         return
 
-    if not inputs and not (update or update_recursive):
+    if not inputs and not (update or update_recursive or ibn):
         click.echo(context.get_help())
         return
 
@@ -179,6 +217,10 @@ def inventree_part_import(
         supplier = only
         only_supplier = True
 
+    if ibn and (update or update_recursive or inputs):
+        error("--ibn cannot be used with --update, --update-recursive, or input arguments")
+        return
+
     if verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
@@ -191,7 +233,11 @@ def inventree_part_import(
         return
 
     parts: list[str | Part]
-    if category_path := update_recursive or update:
+    if ibn:
+        if not (manufacturer_part := _resolve_mouser_ibn(ibn)):
+            return
+        parts = [manufacturer_part]
+    elif category_path := update_recursive or update:
         if update_recursive and update:
             hint("--update is being overridden by --update-recursive")
 

--- a/inventree_part_import/suppliers/supplier_mouser.py
+++ b/inventree_part_import/suppliers/supplier_mouser.py
@@ -73,6 +73,30 @@ class Mouser(ScrapeSupplier):
 
         return list(map(self.get_api_part, filtered_matches)), len(filtered_matches)
 
+    def search_by_ibn(self, ibn_code):
+        if not hasattr(self, "session"):
+            self._setup_session()
+
+        url = f"https://api.mouser.com/api/mobile/v2/search/getIBNs?ibnCode={ibn_code}"
+        for retry in retry_timeouts():
+            with retry:
+                response = self.session.get(url, timeout=self.request_timeout)
+                if response.status_code == 200:
+                    break
+        else:
+            return [], 0
+
+        try:
+            data = response.json()
+        except ValueError:
+            return [], 0
+
+        ibn_list = data.get("IBN", [])
+        if not ibn_list:
+            return [], 0
+
+        return ibn_list
+
     def get_api_part(self, mouser_part):
         mouser_part_number = mouser_part.get("MouserPartNumber")
 

--- a/inventree_part_import/suppliers/supplier_mouser.py
+++ b/inventree_part_import/suppliers/supplier_mouser.py
@@ -74,6 +74,27 @@ class Mouser(ScrapeSupplier):
 
         return list(map(self.get_api_part, filtered_matches)), len(filtered_matches)
 
+    def search_by_ibn(self, ibn_code):
+        if not hasattr(self, "session"):
+            self._setup_session()
+
+        url = f"https://api.mouser.com/api/mobile/v2/search/getIBNs?ibnCode={ibn_code}"
+        response = self.session.get(url, timeout=self.request_timeout)
+        if response.status_code == 200:
+            try:
+                data = response.json()
+            except ValueError:
+                return []
+
+            ibn_list = data.get("IBN", [])
+            if not ibn_list:
+                return []
+
+            return ibn_list
+        return []
+
+
+
     def get_api_part(self, mouser_part: dict[str, Any]):
         supplier_link = DOMAIN_REGEX.sub(
             DOMAIN_SUB.format(self.locale_url), mouser_part.get("ProductDetailUrl", "")


### PR DESCRIPTION
Mobile API allows for searching a part via the IBN barcode on the package label.

example:
```inventree-part-import --ibn 12RKCA```
If multiple entries are returned, user is prompted to choose

Returned data is:

```json
{
    "IBN": [
        {
            "IBNCode": "60W0DO",
            "LifeCycle": null,
            "LineNumber": 35,
            "Manufacturer": "Panasonic",
            "ManufacturerPartnumber": "ERJ-3GEYJ621V",
            "MouserDescription": "0603 620ohms 5% AEC-Q200",
            "MouserPartNumber": "667-ERJ-3GEYJ621V",
            "OrderNumber": "060210436",
            "ProductImageLink": "panasonic/images/ERJ_series_SPL.jpg",
            "Quantity": 10
        }
    ]
}
```