### PR TITLE
suppliers: normalize whitespace in part descriptions

### DIFF
--- a/inventree_part_import/suppliers/base.py
+++ b/inventree_part_import/suppliers/base.py
@@ -35,6 +35,9 @@ class ApiPart:
 
     def __post_init__(self):
         self._fix_urls()
+        # collapse runs of whitespace (incl. non-breaking spaces like \xa0) into a single
+        # regular space; InvenTree's HTML validator rejects descriptions containing them
+        self.description = NORMALIZE_WHITESPACE.sub(" ", self.description).strip()
 
     def finalize(self):
         try:
@@ -202,6 +205,8 @@ DOMAIN_REGEX = re.compile(r"(https?://)(?:[^./]*\.?)*/")
 DOMAIN_SUB = "\\g<1>{}/"
 
 REMOVE_HTML_TAGS = re.compile(r"<.*?>|&([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-f]{1,6});")
+
+NORMALIZE_WHITESPACE = re.compile(r"\s+")
 
 
 def money2float(money: str):


### PR DESCRIPTION
Supplier descriptions can contain non-breaking spaces (\xa0) and other Unicode whitespace, e.g. Mouser returns "Connecteurs RF\xa0/ ...". InvenTree's server-side HTML validator rejects any string its cleaner would alter, so such descriptions fail with
"description: ['Remove HTML tags from this value']" and abort the import.

REMOVE_HTML_TAGS only strips tags and complete &entity; sequences, so it never touched these characters. Normalize whitespace once in ApiPart.__post_init__ (collapsing runs of whitespace, including \xa0, to a single regular space) so every supplier benefits.