### PR TITLE
part_importer: delete price breaks the supplier no longer reports

### DIFF
--- a/inventree_part_import/part_importer.py
+++ b/inventree_part_import/part_importer.py
@@ -330,6 +330,10 @@ class PartImporter:
         if api_part.price_breaks:
             info("updating price breaks ...")
 
+        # delete price breaks the supplier no longer reports, so removed quantity tiers don't linger
+        for quantity in price_breaks.keys() - api_part.price_breaks.keys():
+            price_breaks[quantity].delete()
+
         for quantity, price in api_part.price_breaks.items():
             if price_break := price_breaks.get(quantity):
                 if price == float(price_break.price):


### PR DESCRIPTION
When a supplier drops a quantity tier (e.g. Mouser reducing from many price breaks down to just 1 and 10), the existing InvenTree price breaks for the removed tiers were left untouched. setup_price_breaks treated them as a map and only ever set the quantities the supplier reported, never removing stale ones.

Delete any price break whose quantity is no longer reported by the supplier.