### PR TITLE
suppliers: search all suppliers in parallel

### DIFF
--- a/inventree_part_import/suppliers/__init__.py
+++ b/inventree_part_import/suppliers/__init__.py
@@ -41,10 +41,10 @@ def search(search_term: str, supplier_id: str | None = None, only_supplier: bool
             return None
 
     thread_pool = ThreadPool(processes=8)
-    return (
+    return [
         (api_company, thread_pool.apply_async(supplier_object.cached_search, (search_term,)))
         for supplier_object, api_company in suppliers
-    )
+    ]
 
 
 _supplier_companies: dict[str, InvenTreeCompany] | None = None


### PR DESCRIPTION
This made fetching my diodes category using --update-recursive (with 12 entries) go from 54s to 29s.